### PR TITLE
Add bevy_rapier3d dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 bevy = {version = "0.9.0", features = ["dynamic", "jpeg"]}
 bevy-inspector-egui = "0.14.0"
+# temp fix until bevy_rapier3d supports bevy 0.9
+bevy_rapier3d = { git = "https://github.com/devil-ira/bevy_rapier", branch = "bevy-0.9", features = [ "enhanced-determinism", "wasm-bindgen", "debug-render" ] }
 
 # Enable a small amount of optimization in debug mode
 [profile.dev]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,14 @@ mod monkey;
 
 use bevy::prelude::*;
 use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_rapier3d::prelude::*;
 use monkey::monkey::MonkeyPlugin;
 
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.4, 0.2, 0.2)))
         .add_plugins(DefaultPlugins)
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(WorldInspectorPlugin::new())
         .add_startup_system(setup)
         .add_plugin(MonkeyPlugin)
@@ -34,4 +36,10 @@ fn setup(mut commands: Commands) {
         },
         ..default()
     });
+
+    /* Create the ground. */
+    commands
+        .spawn(())
+        .insert(Collider::cuboid(100.0, 0.1, 100.0))
+        .insert(TransformBundle::from(Transform::from_xyz(0.0, -1.0, 0.0)));
 }

--- a/src/monkey.rs
+++ b/src/monkey.rs
@@ -1,6 +1,7 @@
 pub mod monkey {
     use bevy::prelude::*;
     use bevy_inspector_egui::{Inspectable, RegisterInspectable};
+    use bevy_rapier3d::prelude::*;
     use std::ops::Add;
 
     #[derive(Component)]
@@ -43,6 +44,9 @@ pub mod monkey {
             Player,
             Speed(2.0),
             AnimationState(AnimationStates::Idle),
+            RigidBody::Dynamic,
+            Collider::ball(0.5),
+            Restitution::coefficient(0.7),
             SceneBundle {
                 scene: my_gltf,
                 transform: Transform::from_xyz(0.0, 0.0, 0.0),


### PR DESCRIPTION
Fixes #3 

Temporary solution since at this time bevy_rapier3d does not support bevy 0.9 (see https://github.com/dimforge/bevy_rapier/issues/277)